### PR TITLE
Fixing the appearace of LatLong

### DIFF
--- a/src/app/pages/Details/Details.tsx
+++ b/src/app/pages/Details/Details.tsx
@@ -25,8 +25,8 @@ export default function Details(): JSX.Element {
         <BoxHeading>meet you here</BoxHeading>
         <Location>
           {' '}
-          Lng: {parseFloat(middleLng).toFixed(4)} / Lat:{' '}
-          {parseFloat(middleLat).toFixed(4)}
+          Lat: {parseFloat(middleLat).toFixed(4)} / Lng:{' '}
+          {parseFloat(middleLng).toFixed(4)}
         </Location>
       </PlaceContainer>
       <NavigationContainerMap>


### PR DESCRIPTION
fix the order of lat and lng entry on details page to make it easyer to read.